### PR TITLE
Using exit code 1 of exec for positive virus scan

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,13 +164,14 @@ module.exports = function(options){
 		exec(command, function(err, stdout, stderr) { 
 			if(err || stderr) {
 				// The exit code of a positive virus scan is 1. So not an error, just a positive match
-                if(err.code === 1) {
-                    callback(null, file, true);
-                } else {
-                    if(self.settings.debug_mode)
-						console.log(err);
-					callback(err, file, null);
-                }
+		                if(err.code === 1) {
+		                    callback(null, file, true);
+		                } else {
+		                    if(self.settings.debug_mode) {
+					console.log(err);
+	                    	    }
+				    callback(err, file, null);
+		                }
 			} else {
 				var result = stdout.trim();
 				


### PR DESCRIPTION
Hi,

I noticed that when I test the ClamAV exec with a positive file, that we would get an error.

It turns out that when ClamAV detects a virus, it returns an exit code of 1. Exec, by default, detects this as an error, while in this case it isn't. As a result the clamscan library also sees it as an error.  
This PR corrects the error handling to interpret err.code===1 as a positive virus match.

If you're wondering, we tested the detection of a virus by using [Eicar test file](http://www.eicar.org/86-0-Intended-use.html). When you create a file containing the 68 byte string given there, ClamAV (and other scanners) will see it as positive.

Thanks for making this library! It helped me a great deal. Hopefully this PR helps you in return :-)

Cheers,

Dieter
