### PR TITLE
add list_recursively option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ npm-debug.log
 tests/clamscan-log
 tests/infected/*
 tests/bad_scan_dir/*
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -10,5 +10,11 @@ test: all
 	@touch tests/clamscan-log
 	@./node_modules/.bin/mocha --timeout 5000 --check-leaks --reporter spec $(TESTS)
 
+test_debug: all
+	@mkdir -p tests/infected
+	@mkdir -p tests/bad_scan_dir
+	@touch tests/clamscan-log
+	@./node_modules/.bin/mocha debug --timeout 5000 --check-leaks --reporter spec $(TESTS)
+
 clean:
 	rm -rf node_modules

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ var clam = require('clamscan')({
 	debug_mode: false // Whether or not to log info/debug/error msgs to the console
 	file_list: null, // path to file containing list of files to scan (for scan_files method)
 	scan_recursively: true, // If true, deep scan folders recursively
+    list_recursively: false, // If true, return a list of recursively scanned files not just the root directory
 	clamscan: {
 		path: '/usr/bin/clamscan', // Path to clamscan binary on your server
 		db: null, // Path to a custom virus definition database
@@ -268,6 +269,14 @@ clam.is_infected('/some/file.txt');
 ```
 
 Just keep in mind that some of the nice validation that happens on instantiation won't happen if it's done this way. Of course, you could also just create a new instance with different a different initial configuration.
+
+## Tests
+
+If you have problems running the tests on your system, try to update the clamdscan configuration file path with the environment variable `CLAMD_PATH`:
+
+```javascript
+CLAMD_PATH=/etc/clamav/clamd.conf make test
+```
 
 ## Contribute
 

--- a/index.js
+++ b/index.js
@@ -586,7 +586,7 @@ NodeClam.prototype.scan_dir = function (path, end_cb, file_cb) {
                                 });
 
                             if (self.settings.debug_mode)
-                                console.log("node-clam: finished directory scan and found something in " + bad_files.length + " of " + good_files.length + " files.");
+                                console.log("node-clam: finished directory scan and found something in " + bad_files.length + " of " + (bad_files.length + good_files.length) + " files.");
                             end_cb(null, good_files, bad_files);
                         } else {
                             end_cb(null, [], [path]);

--- a/tests/index.js
+++ b/tests/index.js
@@ -107,6 +107,7 @@ describe('Module', function() {
         expect(clamscan.settings.debug_mode).to.eql(true);
         expect(clamscan.settings.file_list).to.eql( __dirname + '/files_list.txt');
         expect(clamscan.settings.scan_recursively).to.eql(true);
+        expect(clamscan.settings.list_recursively).to.eql(false);
         expect(clamscan.settings.preference).to.eql('clamscan');
 
         // clamscan
@@ -611,6 +612,37 @@ describe('scan_dir', function() {
                         /* if (fs.existsSync(scan_file)) {
                             fs.unlinkSync(scan_file);
                         } */
+                    });
+                });
+            } else {
+                console.log("Could not download test virus file!");
+                console.error(error);
+            }
+        });
+    });
+
+    it('should supply bad_files array with list of actually scanned files when list_recursively is enabled', function(done) {
+        var scan_dir = __dirname + '/bad_scan_dir';
+        var scan_file_1 = __dirname + '/bad_scan_dir/bad_file_1.txt';
+        var scan_file_2 = __dirname + '/bad_scan_dir/bad_file_2.txt';
+
+        request('https://secure.eicar.org/eicar_com.txt', function (error, response, body) {
+            if (!error && response.statusCode == 200) {
+                fs.writeFileSync(scan_file_1, body);
+                fs.writeFileSync(scan_file_2, body);
+
+                clamscan.settings.list_recursively = true;
+
+                clamscan.scan_dir(scan_dir, function(err, good_files, bad_files) {
+                    check(done, function() {
+                        expect(err).to.not.be.instanceof(Error);
+                        expect(bad_files).to.be.an('array');
+                        expect(bad_files).to.have.length(2);
+                        expect(bad_files).to.include(scan_file_1);
+                        expect(bad_files).to.include(scan_file_2);
+
+                        expect(good_files).to.be.an('array');
+                        expect(good_files).to.be.empty;
                     });
                 });
             } else {


### PR DESCRIPTION
I wanted to know the actual "number of found files" even when scanning a directory with `clam.scan_dir(..)`. This adds a new option `list_recursively` to that effect.