### PR TITLE
stderr should be returned to parse_stdout.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -77,3 +77,7 @@ __NOTE:__ There are some breaking changes on this release. Since this is still a
 
 * Updated to `execFile` instead of `exec`
 * Improved test suite
+
+### 0.8.5 (2017-07-31)
+
+* Added `get_clam_version` method

--- a/README.md
+++ b/README.md
@@ -227,6 +227,27 @@ clam.scan_files(files, function(err, good_files, bad_files) {
 });
 ```
 
+### .get_clam_version(end_callback)
+
+Retrieves the version info from the clam binary.
+
+#### Parameters
+
+* `end_callback` (function) Will be called when the version string is retrieved. This callback takes 2 parameters:
+    * `err` (object) A standard javascript Error object (null if no error)
+    * `version_result` (string) String containing version result of the clam binary.
+
+#### Example
+```javascript
+clam.get_clam_version( function(err, version_result) {
+    if(!err) {
+        res.send({"clam_version": version_result});
+    } else {
+        // Do some error handling
+    }
+});
+```
+
 #### Scanning files listed in file list
 
 If this modules is configured with a valid path to a file containing a newline-delimited list of files, it will use the list in that file when scanning if the first paramter passed is falsy.

--- a/index.js
+++ b/index.js
@@ -705,15 +705,15 @@ NodeClam.prototype.get_clam_version = function(callback) {
         if (err || stderr) {
             if (err) {
                 if(err.hasOwnProperty('code') && err.code === 1) {
-                    callback(null, file, true);
+                    callback(null, true);
                 } else {
                     if(self.settings.debug_mode)
                         console.log("node-clam: " + err);
-                    callback(new Error(err), file, null);
+                    callback(new Error(err), null);
                 }
             } else {
                 console.error("node-clam: " + stderr);
-                callback(err, file, null);
+                callback(err, null);
             }
         } else {
             var result = stdout.trim();
@@ -724,14 +724,8 @@ NodeClam.prototype.get_clam_version = function(callback) {
 
             if(result) {
                 if(self.settings.debug_mode)
-                    console.log("node-clam: result!!!", result);
-
-                var version_detail = result.split('/');
-                var final_result = { "version": version_detail[0], "virusdb_version": version_detail[1], "last_update": version_detail[2] };
-                if(self.settings.debug_mode)
-                    console.log("node-clam: final_result", final_result);
-
-                callback(null, final_result);
+                    console.log("node-clam: result:", result);
+                callback(null, result);
             } else {
                 if(self.settings.debug_mode)
                     console.log("node-clam: missing result");

--- a/index.js
+++ b/index.js
@@ -415,7 +415,7 @@ NodeClam.prototype.scan_files = function(files, end_cb, file_cb) {
                         }
                     }
 
-                    return parse_stdout(err, stdout);
+                    return parse_stdout(stderr, stdout);
                 });
             };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clamscan",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "author": "Kyle Farris <kfarris@chomponllc.com> (http://chomponllc.com)",
   "description": "Use Node JS to scan files on your server with ClamAV's clamscan binary or clamdscan daemon. This is especially useful for scanning uploaded files provided by un-trusted sources.",
   "main": "index.js",
@@ -8,7 +8,8 @@
     "dietervds",
     "nicolaspeixoto",
     "urg <Patrick McAndrew>",
-    "SaltwaterC <Ștefan Rusu>"
+    "SaltwaterC <Ștefan Rusu>",
+    "Spuddermax <Matthew Daines>"
   ],
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
Whenever I would get a positive virus match, the err object was being set. I'm assuming stderr is the appropriate return object in this instance.