### PR TITLE
Fix undefined reference on an empty stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -1034,7 +1034,9 @@ class NodeClam {
                 // TODO: Investigate why this needs to be done in order
                 // for the ClamAV socket to be closed (why NodeClamTransform's
                 // `_flush` method isn't getting called)
-                if (this._clamav_socket.writable === true) {
+                // If the incoming stream is empty, transform() won't have been called, so we won't
+                // have a socket here.
+                if (this._clamav_socket && this._clamav_socket.writable === true) {
                     const size = Buffer.alloc(4);
                     size.writeInt32BE(0, 0);
                     this._clamav_socket.write(size, cb);

--- a/tests/index.js
+++ b/tests/index.js
@@ -8,6 +8,7 @@ const should = chai.should();
 const expect = chai.expect;
 const config = require('./test_config');
 const good_scan_dir = __dirname + '/good_scan_dir';
+const empty_file = `${good_scan_dir}/empty_file.txt`;
 const good_scan_file = `${good_scan_dir}/good_file_1.txt`;
 const good_file_list = __dirname + '/good_files_list.txt';
 const bad_scan_dir = __dirname + '/bad_scan_dir';
@@ -1347,6 +1348,22 @@ describe('passthrough', () => {
 
         output.on('finish', () => {
             const orig_file = fs.readFileSync(good_scan_file);
+            const out_file = fs.readFileSync(passthru_file);
+
+            expect(orig_file).to.eql(out_file);
+            if (fs.existsSync(passthru_file)) fs.unlinkSync(passthru_file);
+        });
+    });
+
+    it('should handle a 0-byte file', () => {
+        const input = fs.createReadStream(empty_file);
+        const output = fs.createWriteStream(passthru_file);
+        const av = clamscan.passthrough();
+
+        input.pipe(av).pipe(output);
+
+        output.on('finish', () => {
+            const orig_file = fs.readFileSync(empty_file);
             const out_file = fs.readFileSync(passthru_file);
 
             expect(orig_file).to.eql(out_file);


### PR DESCRIPTION
If an incoming stream is empty, the underlying `Transform` stream will call `flush()` without having called `transform()`. This results in the following error:
```
TypeError: uncaughtException: Cannot read property 'writable' of undefined
    at Transform.flush [as _flush] (/usr/src/app/node_modules/clamscan/index.js:1037:41)
    at Transform.prefinish (_stream_transform.js:141:10)
    at Transform.emit (events.js:198:13)
    at Transform.EventEmitter.emit (domain.js:466:23)
    at prefinish (_stream_writable.js:635:14)
    at finishMaybe (_stream_writable.js:643:5)
    at endWritable (_stream_writable.js:663:3)
    at Transform.Writable.end (_stream_writable.js:594:5)
    at FileStream.onend (_stream_readable.js:671:10)
    at Object.onceWrapper (events.js:286:20)
    at FileStream.emit (events.js:203:15)
    at FileStream.EventEmitter.emit (domain.js:466:23)
    at endReadableNT (_stream_readable.js:1145:12)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```