### PR TITLE
Allow transform destroy to flush on an infected file.

### DIFF
--- a/NodeClamTransform.js
+++ b/NodeClamTransform.js
@@ -33,9 +33,11 @@ class NodeClamTransform extends Transform {
 
     _flush(cb) {
         if (this._debug_mode) console.log("node-clam: Received final data from stream.");
-        const size = Buffer.alloc(4);
-        size.writeInt32BE(0, 0);
-        this.push(size);
+        if (!this._readableState.ended) {
+            const size = Buffer.alloc(4);
+            size.writeInt32BE(0, 0);
+            this.push(size);
+        }
         cb();
     }
 }


### PR DESCRIPTION
We've bolted ClamScan into Meteor.  On testing an infected file, we see the following error.  The change corrects it.
```
W20200120-14:47:30.650(8)? (STDERR) Error: stream.push() after EOF
W20200120-14:47:30.650(8)? (STDERR)     at readableAddChunk (_stream_readable.js:240:30)
W20200120-14:47:30.650(8)? (STDERR)     at NodeClamTransform.Readable.push (_stream_readable.js:208:10)
W20200120-14:47:30.651(8)? (STDERR)     at NodeClamTransform.Transform.push (_stream_transform.js:147:32)
W20200120-14:47:30.651(8)? (STDERR)     at NodeClamTransform._flush (/home/cui/loudspeed-admin/.meteor/local/isopacks/loudspeed_node-modules/npm/node_modules/clamscan/NodeClamTransform.js:38:14)
W20200120-14:47:30.651(8)? (STDERR)     at NodeClamTransform.prefinish (_stream_transform.js:137:10)
W20200120-14:47:30.651(8)? (STDERR)     at emitNone (events.js:106:13)
W20200120-14:47:30.651(8)? (STDERR)     at NodeClamTransform.emit (events.js:208:7)
W20200120-14:47:30.651(8)? (STDERR)     at prefinish (_stream_writable.js:602:14)
W20200120-14:47:30.651(8)? (STDERR)     at finishMaybe (_stream_writable.js:610:5)
W20200120-14:47:30.651(8)? (STDERR)     at endWritable (_stream_writable.js:621:3)
W20200120-14:47:30.651(8)? (STDERR)     at NodeClamTransform.Writable.end (_stream_writable.js:572:5)
W20200120-14:47:30.652(8)? (STDERR)     at NodeClamTransform.Duplex._destroy (_stream_duplex.js:118:8)
W20200120-14:47:30.652(8)? (STDERR)     at NodeClamTransform.Transform._destroy (_stream_transform.js:196:29)
W20200120-14:47:30.652(8)? (STDERR)     at NodeClamTransform.destroy (internal/streams/destroy.js:32:8)
W20200120-14:47:30.652(8)? (STDERR)     at handle_error (/home/cui/loudspeed-admin/.meteor/local/isopacks/loudspeed_node-modules/npm/node_modules/clamscan/index.js:927:44)
W20200120-14:47:30.652(8)? (STDERR)     at Socket._clamav_socket.on.on.on.on.on.on.cv_chunk (/home/cui/loudspeed-admin/.meteor/local/isopacks/loudspeed_node-modules/npm/node_modules/clamscan/index.js:1014:41)
```