### PR TITLE
Fix documentation for scan_stream Promise return

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ This method allows you to scan a binary stream. **NOTE**: This method will only 
 
 - Promise
 
-  - Promise resolution returns: `result` (onject)
+  - Promise resolution returns: `result` (object):
 
     - `file` (string) **NULL** as no file path can be provided with the stream
     - `is_infected` (boolean) **True**: File is infected; **False**: File is clean. **NULL**: Unable to scan.

--- a/README.md
+++ b/README.md
@@ -538,7 +538,11 @@ This method allows you to scan a binary stream. **NOTE**: This method will only 
 
 - Promise
 
-  - Promise resolution returns: `is_infected` (boolean)
+  - Promise resolution returns: `result` (onject)
+
+    - `file` (string) **NULL** as no file path can be provided with the stream
+    - `is_infected` (boolean) **True**: File is infected; **False**: File is clean. **NULL**: Unable to scan.
+    - `viruses` (array) An array of any viruses found in the scanned file.
 
 ### Examples
 
@@ -572,7 +576,7 @@ clamscan.scan_stream(stream, (err, is_infected) => {
 **Promise Example:**
 
 ```javascript
-clamscan.scan_stream(stream).then(is_infected => {
+clamscan.scan_stream(stream).then(({is_infected}) => {
     if (is_infected) return console.log("Stream is infected! Booo!");
     console.log("Stream is not infected! Yay!");
 }).catch(err => {

--- a/README.md
+++ b/README.md
@@ -538,12 +538,7 @@ This method allows you to scan a binary stream. **NOTE**: This method will only 
 
 - Promise
 
-  - Promise resolution returns: `result` (object):
-
-    - `good_files` (array) List of the full paths to all files that are _clean_.
-    - `bad_files` (array) List of the full paths to all files that are _infected_.
-    - `errors` (object) Per-file errors keyed by the filename in which the error happened. (ex. `{'foo.txt': Error}`)
-    - `viruses` (array) List of all the viruses found (feature request: associate to the bad files).
+  - Promise resolution returns: `is_infected` (boolean)
 
 ### Examples
 


### PR DESCRIPTION
The Promise return description was probably copied from a function that scans multiple files, but it only resolves to a boolean. Fixed the text accordingly