### PR TITLE
fix: node 16 passthrough multiple callback error

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,14 +12,10 @@ const fs = require('fs');
 const nodePath = require('path'); // renamed to prevent conflicts in `scanDir`
 const { promisify } = require('util');
 const { execFile } = require('child_process');
-const { PassThrough, Transform, ReadableStream } = require('stream');
+const { PassThrough, Transform, Readable } = require('stream');
 const { Socket } = require('dgram');
 const NodeClamError = require('./lib/NodeClamError');
 const NodeClamTransform = require('./lib/NodeClamTransform.js');
-
-/**
- * @typedef {ReadableStream} ReadableStream
- */
 
 // Enable these once the FS.promises API is no longer experimental
 // const fsPromises = require('fs').promises;
@@ -2106,7 +2102,7 @@ class NodeClam {
      * use of a TCP or UNIX Domain socket. In other words, this will not work if you only
      * have access to a local ClamAV binary.
      *
-     * @param {ReadableStream} stream - A readable stream to scan
+     * @param {Readable} stream - A readable stream to scan
      * @param {Function} [cb] - What to do when the socket response with results
      * @returns {Promise<object>} Object like: `{ file: String, isInfected: Boolean, viruses: Array }`
      * @example


### PR DESCRIPTION
Node 16 includes a behavior change that breaks many stream implementation functions if they use async/await syntax. Async functions implicitly return a Promise, and node's stream internals [automatically call the underlying callback](https://github.com/nodejs/node/blob/418ff70b810f0e7112d48baaa72932a56cfa213b/lib/internal/streams/transform.js#L209-L234) if the function's result is a thenable. There is [some logic](https://github.com/nodejs/node/blob/418ff70b810f0e7112d48baaa72932a56cfa213b/lib/internal/streams/transform.js#L214-L215) to skip the automatic callback if it was already called explicitly in the function; however, this can execute before other asynchronous tasks, which results in a `ERR_MULTIPLE_CALLBACK` error when the explicit callback is invoked. For example, the callback in [this `drain` event handler](https://github.com/kylefarris/clamscan/blob/c1d4f4c6114dbe74e7e40954944b70f3ac871b90/index.js#L1185-L1199) will often trigger the error:

```js
async transform(chunk, encoding, cb) {
  if (!forkStream.write(chunk)) {
    forkStream.once('drain', () => {
      cb(null, chunk);
    });
  } else {
    cb(null, chunk);
  }
}
```
This new behavior for thenables is undocumented and has already been deprecated. Unfortunately, we need to live with it for now. The most straightforward solution is to use a Promise chain instead of async/await in NodeClam `passthrough()`'s `Transform` implementation.

This PR also makes a change to use `stream.Readable` in jsdoc instead of `ReadableStream` from the experimental Web Streams API. (Complementary types change in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58698.)

Fixes #82 

Refs https://github.com/nodejs/node/issues/39535, https://github.com/nodejs/node/pull/40773
