### PR TITLE
Update examples with camelCase

### DIFF
--- a/examples/passthrough.js
+++ b/examples/passthrough.js
@@ -36,11 +36,11 @@ async function removeFinalFile() {
  */
 async function test() {
     const clamscan = await new NodeClam().init({
-        debug_mode: true,
+        debugMode: true,
         clamdscan: {
             host: 'localhost',
             port: 3310,
-            bypass_test: true,
+            bypassTest: true,
             // socket: '/var/run/clamd.scan/clamd.sock',
         },
     });

--- a/examples/stream.js
+++ b/examples/stream.js
@@ -14,9 +14,9 @@ const NodeClam = require('../index.js'); // Offically: require('clamscan');
  */
 async function test() {
     const clamscan = await new NodeClam().init({
-        debug_mode: false,
+        debugMode: false,
         clamdscan: {
-            bypass_test: true,
+            bypassTest: true,
             host: 'localhost',
             port: 3310,
             socket: '/var/run/clamd.scan/clamd.sock',

--- a/examples/version.js
+++ b/examples/version.js
@@ -2,12 +2,12 @@
 const NodeClam = require('../index.js'); // Offically: require('clamscan');
 
 const ClamScan = new NodeClam().init({
-    debug_mode: false,
+    debugMode: false,
     // prettier-ignore
     clamdscan: {
         // Run scan using command line
         path: '/usr/bin/clamdscan',                // <-- Secondary fallback to command line -|
-        config_file: '/etc/clamd.d/daemon.conf',   // <---------------------------------------|
+        configFile: '/etc/clamd.d/daemon.conf',   // <---------------------------------------|
         // Connect via Host/Port
         host: 'localhost',                         // <-- Primary fallback - |
         port: 3310,                                // <----------------------|
@@ -23,6 +23,6 @@ const ClamScan = new NodeClam().init({
 });
 
 ClamScan.then(async (av) => {
-    const result = await av.get_version();
+    const result = await av.getVersion();
     console.log('Version: ', result);
 });


### PR DESCRIPTION
Some examples were still using the snake_case syntax removed in v2.0.0, this updates them to the current camelCase.