### PR TITLE
Add check: if server closes the connection before PONG

### DIFF
--- a/index.js
+++ b/index.js
@@ -692,7 +692,17 @@ class NodeClam {
                     console.log(`${this.debugLabel}: Established connection to clamscan server!`);
 
                 client.write('PING');
+
+                let dataReceived = false;
+                client.on('end', () => {
+                    if (!dataReceived) {
+                        const err = new NodeClamError('Did not get a PONG response from clamscan server.');
+                        return hasCb ? cb(err, null) : reject(err);
+                    }
+                });
+
                 client.on('data', (data) => {
+                    dataReceived = true;
                     if (data.toString().trim() === 'PONG') {
                         if (this.settings.debugMode) console.log(`${this.debugLabel}: PONG!`);
                         return hasCb ? cb(null, client) : resolve(client);


### PR DESCRIPTION
In some scenarios, the server can enter a state where even though it accepts connection, it closes it and doesn't reply with `PONG` when you send the `PING`

Specially when clamav has trouble downloading database updates (due to rate-limiting imposed by clam-av)

Working scenario:
![image](https://user-images.githubusercontent.com/8508500/156469300-e6e32838-3ce8-423e-ad77-ed5f46995268.png)

Scenario where it breaks:
![image](https://user-images.githubusercontent.com/8508500/156469413-765d778a-54b0-4aac-8541-6dfcee58fb1d.png)
(connection gets closed prematurely)