### PR TITLE
Fixed issue when this._clamavSocket is not defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -1216,7 +1216,9 @@ class NodeClam {
                     this._forkStream.unpipe();
                     this._forkStream.destroy();
                     this._clamavTransform.destroy();
-                    this._clamavSocket.end();
+                    if (this._clamavSocket) {
+                        this._clamavSocket.end();
+                    }
                     clearScanBenchmark();
 
                     // Finding an infected file isn't really an error...


### PR DESCRIPTION
this._clamavSocket is not defined when connection could not be established or was lost