### PR TITLE
On TCP Socket error, pass the error details

### DIFF
--- a/index.js
+++ b/index.js
@@ -1102,7 +1102,7 @@ class NodeClam {
                         if (this.settings.clamdscan.localFallback === true) return await localScan();
 
                         // Otherwise, fail
-                        const err = new NodeClamError({ err: e, file }, 'Could not scan file via TCP or locally!');
+                        const err = new NodeClamError({ err: e, file }, `Could not scan file via TCP or locally! ${e.message}`);
                         return hasCb ? cb(err, file, null, []) : reject(err);
                     } finally {
                         // Kill file stream on response


### PR DESCRIPTION
Hi @kylefarris ,

it would be great, if you could merge and release my PR. this is needed, as there are situations when I need to know the TCP Socket error details, eg. when the clamd returns `INSTREAM size limit exceeded. ERROR` (file size exceeding MaxFileSize).

Regards
  stheine