### PR TITLE
fix: file is always null when using a server via tcp

### DIFF
--- a/index.js
+++ b/index.js
@@ -1111,7 +1111,7 @@ class NodeClam {
                     // Attempt to scan the stream.
                     try {
                         const isInfected = await this.scanStream(stream);
-                        return hasCb ? cb(null, file, isInfected, []) : resolve({ file, ...isInfected });
+                        return hasCb ? cb(null, file, isInfected, []) : resolve({ ...isInfected, file });
                     } catch (e) {
                         // Fallback to local if that's an option
                         if (this.settings.clamdscan.localFallback === true) return await localScan();


### PR DESCRIPTION
fix: file is always null when a file is turned into a stream and then sent to a server