### PR TITLE
fix: handle ping timeout error after client created

### DIFF
--- a/index.js
+++ b/index.js
@@ -1469,6 +1469,11 @@ class NodeClam {
                     }
                     return hasCb ? cb(err, null) : reject(err);
                 });
+                client.on('timeout', () => {
+                    if (this.settings.debugMode) console.log(`${this.debugLabel}: Socket/Host connection timed out.`);
+                    client.end();
+                    reject(new Error('Connection to host has timed out.'));
+                });
             } catch (err) {
                 return hasCb ? cb(err, false) : reject(err);
             }


### PR DESCRIPTION
Fix for timeout error on ping request using remote server.

### Explanation

The timeout error is thrown after the client is created and the promise is neither resolved nor rejected.

To fix this, the ping method should handle the timeout error after the client is created.

### Test scenario

First, run a clamav server.

```yaml
services:
  clamav:
    image: tiredofit/clamav
    ports:
      - 3310:3310
    volumes:
      - clamav_data:/data
      - clamav_logs:/logs

volumes:
  clamav_data:
  clamav_logs:

```

Then, block traffic for clamav server.

```bash
sudo iptables -D INPUT -p tcp --dport 3310 -j DROP
```

```bash
sudo iptables -D OUTPUT -p tcp --dport 3310 -j DROP
```

And finally, try to connect to clamav server.

```typescript
try {
    const client = await new NodeClam().init({
            clamdscan: {
                host: 'localhost',
                port: 3310,
                timeout: 2_000,
            },
            preference: 'clamdscan',
        });
} catch(err) {
    console.error('Failed to create ClamAV client', err);
}
```
